### PR TITLE
Make the installer work when an existing database is selected

### DIFF
--- a/pandora_console/install.php
+++ b/pandora_console/install.php
@@ -805,7 +805,7 @@ function install_step4() {
 							check_generic ($step1, "Creating database '$dbname'");
 						}
 						else {
-							$step = 1;
+							$step1 = 1;
 						}
 						if ($step1 == 1) {
 							$step2 = mysql_select_db($dbname);


### PR DESCRIPTION
The code in the installer script is a little confusing, but I'm 99% sure that the variable here should be $step1 and not $step - $step is never evaluated, and the remaining steps rely on $step1 being true, meaning there is no way an installation can ever complete if an existing database is selected.

As the code stands, the installer connects to the database, then aborts the installation without giving an error. With this change it installs properly and successfully for me.
